### PR TITLE
fix: post title too long in mobile devices

### DIFF
--- a/source/sass/component/_item-post.scss
+++ b/source/sass/component/_item-post.scss
@@ -37,3 +37,27 @@
     }
   }
 }
+
+@media screen and (min-width: 400px) and (max-width: 500px) {
+  .item-post {
+    .post-title {
+      max-width: 330px;
+    }
+  }
+}
+
+@media screen and (min-width: 320px) and (max-width: 399px) {
+  .item-post {
+    .post-title {
+      max-width: 250px;
+    }
+  }
+}
+
+@media screen and (max-width: 319px) {
+  .item-post {
+    .post-title {
+      max-width: 200px;
+    }
+  }
+}


### PR DESCRIPTION
修复了文章列表下文章标题在小屏幕设备中过长的问题。

PS: 其实还有个暴力点的方式，就是 `max-width: calc(100% - 65px)` ，但低版本安卓和低版本 ie 不支持... 所以就用了 media-query 的方式。