### PR TITLE
Add English support in locations and other places

### DIFF
--- a/languages/default.yml
+++ b/languages/default.yml
@@ -10,3 +10,14 @@ archive_a: Archives
 archive_b: "Archives: %s"
 page: Page %d
 recent_posts: Recent Posts
+close: Close
+posts_list: Posts List
+location:
+	about: About
+	blog: Blog
+	categories: Categories
+	links: Links
+	projects: Projects
+	search: Search
+	tags: Tags
+	

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -10,3 +10,13 @@ archive_a: 归档
 archive_b: 归档：%s
 page: 第 %d 页
 recent_posts: 最新文章
+close: 关闭
+posts_list: 文章目录
+location:
+	about: 关于
+	blog: 博客
+	categories: 分类
+	links: 友链
+	projects: 项目
+	search: 搜索
+	tags: 标签

--- a/layout/_partial/component/category-box.ejs
+++ b/layout/_partial/component/category-box.ejs
@@ -1,5 +1,5 @@
 <section class="category-box">
-  <div class="category-title">分类</div>
+  <div class="category-title"><%= __('categories') %></div>
   <div class="category-list">
     <% site.categories.sort('name').each(function (category, i) { %>
       <a class="category-item" href="#<%= category.name %>">

--- a/layout/_partial/component/modal.ejs
+++ b/layout/_partial/component/modal.ejs
@@ -2,7 +2,7 @@
   <span id="cover" class="cover hide"></span>
   <div id="modal-dialog" class="modal-dialog hide-dialog">
     <div class="modal-header">
-      <span id="close" class="btn-close">关闭</span>
+      <span id="close" class="btn-close"><%= __('close') %></span>
     </div>
     <hr>
     <div class="modal-body">

--- a/layout/_partial/component/tag-box.ejs
+++ b/layout/_partial/component/tag-box.ejs
@@ -1,5 +1,5 @@
 <section class="tag-box">
-  <div class="tag-title">标签</div>
+  <div class="tag-title"><%= __('tags') %></div>
   <div class="tag-list">
     <% site.tags.sort('name').each(function(tag) { %>
       <a class="tag-item" href="#<%= tag.name %>">

--- a/layout/_partial/component/toc.ejs
+++ b/layout/_partial/component/toc.ejs
@@ -1,6 +1,6 @@
 <% if(theme.post.showToc && toc(page.content).length !== 0) { %>
   <div id="toc" class="toc-article">
-    <strong class="toc-title">文章目录</strong>
+    <strong class="toc-title"><%= __('posts_list') %></strong>
     <%- toc(page.content, {list_number: false}) %>
   </div>
 <% } %>

--- a/layout/about.ejs
+++ b/layout/about.ejs
@@ -1,5 +1,5 @@
 <div class="content content-about">
-  <%- partial('_partial/component/page-header', {location: '关于'}) %>
+  <%- partial('_partial/component/page-header', {location: __('location.about')}) %>
 
   <ul class="about-list">
     <% theme.about.forEach(function(item, i){ %>

--- a/layout/archive.ejs
+++ b/layout/archive.ejs
@@ -1,5 +1,5 @@
 <div class="content content-archive">
-  <%- partial('_partial/component/page-header', {location: '博客'}) %>
+  <%- partial('_partial/component/page-header', {location: __('location.blog')}) %>
 
   <div class="post-list-box archive-body">
     <%- getPostListsDom(page.posts) %>

--- a/layout/category.ejs
+++ b/layout/category.ejs
@@ -1,5 +1,5 @@
 <div class="content content-category">
-  <%- partial('_partial/component/page-header', {location: '分类'}) %>
+  <%- partial('_partial/component/page-header', {location: __('location.categories')}) %>
   <%- partial('_partial/component/category-box') %>
   <%- getPostListsDom(site.categories.sort('name')) %>
 </div>

--- a/layout/link.ejs
+++ b/layout/link.ejs
@@ -1,5 +1,5 @@
 <div class="content content-link">
-  <%- partial('_partial/component/page-header', {location: '友链'}) %>
+  <%- partial('_partial/component/page-header', {location: __('location.link')}) %>
 
   <hr>
 

--- a/layout/project.ejs
+++ b/layout/project.ejs
@@ -1,5 +1,5 @@
 <div class="content content-project">
-  <%- partial('_partial/component/page-header', {location: '项目'}) %>
+  <%- partial('_partial/component/page-header', {location: __('location.projects')}) %>
 
   <ul class="project-list">
     <% theme.project.forEach(function(item, i){ %>

--- a/layout/search.ejs
+++ b/layout/search.ejs
@@ -1,5 +1,5 @@
 <div class="content content-search">
-  <%- partial('_partial/component/page-header', {location: '搜索'}) %>
+  <%- partial('_partial/component/page-header', {location: __('location.search')}) %>
   <div class="wrap-search-box">
     <div class="search-box">
       <input id="input-search"  class="input-search" type="text" placeholder="search">

--- a/layout/tag.ejs
+++ b/layout/tag.ejs
@@ -1,5 +1,5 @@
 <div class="content content-tag">
-  <%- partial('_partial/component/page-header', {location: '标签'}) %>
+  <%- partial('_partial/component/page-header', {location: __('location.tags')}) %>
   <%- partial('_partial/component/tag-box') %>
   <%- getPostListsDom(site.tags.sort('name'))%>
 </div>


### PR DESCRIPTION
增加了Location等地点的default英语翻译。（把原来是hardcoded在template中的标题改为Hexo的Internationalization实现）
Aim to fix #48
已知的问题： 
1. 如Category这样长的英语单词在小圆里面会overflow，不是很好看
2. no和繁体的翻译没有实现。
