### PR TITLE
增加了不算子插件，用来显示文章访问量，修复了多说bug，实现了文章评论数的显示

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -128,8 +128,10 @@ baidu_analytics: 57e94d016e201fba3603a8a2b0263af0
 
 # Comment service
 disqus_shortname: forsigner
-# duoshuo_shortname: forsigner
+duoshuo_shortname: forsigner
 
+# 不算子,文章访问量统计和显示
+busuanzi: true
 
 # =========================================================
 # 页面内容设置

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -24,6 +24,19 @@
         </span>
       <% } %>
 
+      <% if (theme.busuanzi){ %>
+      <i class="fa fa-eye"></i> 
+        <span id="busuanzi_container_page_pv">
+           &nbsp热度 <span id="busuanzi_value_page_pv">
+           <i class="fa fa-spinner fa-spin"></i></span>℃
+        </span>
+      <% } %>
+
+      <% if (theme.duoshuo_shortname){ %>
+        <i class="icon-comment"></i> 
+        <span class="ds-thread-count" data-thread-key="<%= page.layout %>-<%= page.slug %>"><i class="fa fa-spinner fa-spin"></i></span> 条评论
+      <% } %>
+      
     </div>
   </header>
 

--- a/layout/_partial/component/duoshuo.ejs
+++ b/layout/_partial/component/duoshuo.ejs
@@ -1,7 +1,8 @@
 <% if (page.comments && theme.duoshuo_shortname){ %>
   <section class="duoshuo-comments">
     <!-- 多说评论框 start -->
-    <div class="ds-thread" data-thread-key="<%= url %>" data-title="<%= page.title %>" data-url="<%= url %>"></div>
+    <div class="ds-thread" data-thread-key="<%= page.layout %>-<%= page.slug %>" 
+      data-title="<%= page.title %>" data-url="<%= url %>"></div>
     <!-- 多说评论框 end -->
   </section>
 <% } %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -53,4 +53,12 @@
 
   <%- partial('google-analytics') %>
   <%- partial('baidu-analytics') %>
+
+  <% if (theme.busuanzi){ %>
+    <script async src="https://dn-lbstatics.qbox.me/busuanzi/2.3/busuanzi.pure.mini.js"></script>
+  <% } %>
+
+  <% if (theme.busuanzi || theme.duoshuo_shortname){ %>
+    <link rel="stylesheet" href="//cdn.bootcss.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <% } %>
 </head>


### PR DESCRIPTION
查看多说官方文档，有如下发现：

data-thread-key中:和,即冒号和逗号有特别的用途，请不要使用url或其他有这两个符号的内容作为data-thread-key。

参考链接：
1. http://dev.duoshuo.com/docs/5003ecd94cab3e7250000008
2. https://bruceyu1994.github.io/2016/10/22/Fexo/

Fexo主题默认的多说data-thread-key是url,包含”:”,这是Fexo主题的一大不足