### PR TITLE
多说等第三方评论插件已经失效，改用Gitalk插件

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -128,7 +128,8 @@ google_analytics:
 baidu_analytics: 57e94d016e201fba3603a8a2b0263af0
 
 # Comment service
-disqus_shortname: forsigner
+# disqus_shortname: forsigner
+gitalk_shortname: forsigner
 # hypercomments_id: 89821
 # gentie_key: d16a7241e7cd4b389584ed8db2a4e8bc
 

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -31,11 +31,6 @@
            <i class="fa fa-spinner fa-spin"></i></span>℃
         </span>
       <% } %>
-
-      <% if (theme.duoshuo_shortname){ %>
-        <i class="icon-comment"></i> 
-        <span class="ds-thread-count" data-thread-key="<%= page.layout %>-<%= page.slug %>"><i class="fa fa-spinner fa-spin"></i></span> 条评论
-      <% } %>
       
     </div>
   </header>
@@ -52,4 +47,11 @@
       <%- post.content %>
     <% } %>
   </div>
+
+  <% if (theme.gitalk_shortname && page.comments && theme.url){ %>
+      <%- partial('component/gitalk') %>
+  <% } else { %>
+      <div class="git"></div>
+  <% } %>
+
 </article>

--- a/layout/_partial/component/gitalk.ejs
+++ b/layout/_partial/component/gitalk.ejs
@@ -1,0 +1,20 @@
+<% if (theme.gitalk_shortname){ %>
+<!-- Gitalk评论插件通用代码 -->
+<div id="git"></div>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.css">
+<script src="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js"></script>
+<script>
+const gitalk = new Gitalk({
+  clientID: 'fa6d900315185857f892',
+  clientSecret: 'b93e7901b0b17ae685221aacd6348824aa737d85',
+  repo: 'BlogComments',
+  owner: 'icebergcwp1990',
+  admin: ['icebergcwp1990'],
+  // facebook-like distraction free mode
+  distractionFreeMode: false
+})
+gitalk.render('git')
+</script>
+<!-- Gitalk代码结束 -->
+
+<% } %>

--- a/layout/_partial/component/gitalk.ejs
+++ b/layout/_partial/component/gitalk.ejs
@@ -5,11 +5,11 @@
 <script src="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js"></script>
 <script>
 const gitalk = new Gitalk({
-  clientID: 'fa6d900315185857f892',
-  clientSecret: 'b93e7901b0b17ae685221aacd6348824aa737d85',
-  repo: 'BlogComments',
-  owner: 'icebergcwp1990',
-  admin: ['icebergcwp1990'],
+  clientID: 'Github Application Client ID',
+  clientSecret: 'Github Application Client Secret',
+  repo: '用于存储评论的仓库名称',
+  owner: 'github用户名',
+  admin: ['github用户名'],
   // facebook-like distraction free mode
   distractionFreeMode: false
 })


### PR DESCRIPTION
1、在在_config.yml文件中添加了新属性：gitalk_shortname，注释了之前的disqus_shortname属性
2、在目录/layout/_partial/component/下添加了文件gitalk.ejs
3、layout/_partial/article.ejs添加引入gitalk插件的代码