### PR TITLE
在不更新gitalk的情况下解决Error Validation Failed

### DIFF
--- a/layout/_partial/component/gitalk.ejs
+++ b/layout/_partial/component/gitalk.ejs
@@ -5,6 +5,7 @@
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.css">
 <script src="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js"></script>
+<script src="//cdn.bootcss.com/blueimp-md5/2.10.0/js/md5.js"></script>
 <script>
 const gitalk = new Gitalk({
   clientID: '<%= theme.gitalk.clientID %>',
@@ -14,7 +15,7 @@ const gitalk = new Gitalk({
   // 在这里设置一下截取前50个字符串, 这是因为 github 对 label 的长度有了要求, 如果超过
   // 50个字符串则会报错.
   // id: location.pathname.split('/').pop().substring(0, 49),
-  id: location.pathname,
+  id: md5(location.pathname),
   admin: ['<%= theme.gitalk.admin %>'],
   // facebook-like distraction free mode
   distractionFreeMode: false


### PR DESCRIPTION
其他的主题也有遇到过类似情况，gitalk官方新版提供了解决方案，旧版版可以采用该方式进行解决，其他主题也有采用该方法，我在自己的博客www.shenjian.online中遇到过，验证可以(也是用的博主的fexo主题)