### PR TITLE
Update pagination.ejs

### DIFF
--- a/layout/_partial/component/pagination.ejs
+++ b/layout/_partial/component/pagination.ejs
@@ -4,7 +4,8 @@
       <%- paginator({
         prev_text: '<i class="icon-angle-left"></i>',
         next_text: '<i class="icon-angle-right"></i>',
-        mid_size: 1
+        mid_size: 1,
+        escape: false
       }) %>
     </nav>
   </div>


### PR DESCRIPTION
https://hexo.io/zh-cn/docs/helpers.html#paginator
目前版本的hexo好像加入了escape选项……默认情况下会把html tag忽略掉，导致切页按钮出现点偏差……